### PR TITLE
Possible Fix For Issue #2

### DIFF
--- a/lib/GridStream_impl.cc
+++ b/lib/GridStream_impl.cc
@@ -57,7 +57,7 @@ namespace gr {
     {
     message_port_register_in(PMTCONSTSTR__PDU_IN);
     set_msg_handler(PMTCONSTSTR__PDU_IN,
-                    boost::bind(&GridStream_impl::general_work, this, _1));
+                    boost::bind(&GridStream_impl::pdu_handler, this, _1));
     message_port_register_out(PMTCONSTSTR__PDU_OUT);    	    
 	}
 


### PR DESCRIPTION
Hi,

I think I found the the solution for the problem I ran into in #2.

Looking over the last commit #1, I saw that GridStream_impl::general_work was renamed to GridStream_impl::pdu_handler. There's a Boost Bind call on line 60 in GridStream_impl.cc that was still referencing GridStream_impl::general_work. I updated general_work to pdu_handler and was able to successfully compile the code. Not fully tested but GRC loads the block without any errors.

Thanks!    