### PR TITLE
Update README.md - add We Energies CRC

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,3 +17,5 @@ Seattle, WA   |   Seattle City Light  |   CRC = 0x23D1
 Santa Barbara, CA   |   Southern California Edison   |   CRC = 0x2C22
 
 Washington   |   Puget Sound Energy   |   CRC = 0x142A
+
+Milwaukee, WI   |   We Energies   |   CRC = 0x4E2D


### PR DESCRIPTION
Adds We Energies 

Note: they do not include GPS coordinates, but you can modify the old python script and add a socket PDU to show the uptime by meter ID