### PR TITLE
Add APS CRC value to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,5 @@ Washington   |   Puget Sound Energy   |   CRC = 0x142A
 Milwaukee, WI   |   We Energies   |   CRC = 0x4E2D
 
 Kansas City  |   Evergy               |   CRC = 0xE623
+
+Phoenix, AZ  |   APS                  |   CRC = 0x1D65


### PR DESCRIPTION
It seems the CRC for APS in the Phoenix, AZ area is 0x1D65

Note: Their IDs do not seem to be based on GPS coordinates.